### PR TITLE
feat: add plog options

### DIFF
--- a/include/scopi/scopi.hpp
+++ b/include/scopi/scopi.hpp
@@ -2,16 +2,21 @@
 
 #include <CLI/CLI.hpp>
 
-#define SCOPI_PARSE(argc, argv)       \
-    try                               \
-    {                                 \
-        auto& app = scopi::get_app(); \
-        app.parse(argc, argv);        \
-    }                                 \
-    catch (const CLI::ParseError& e)  \
-    {                                 \
-        auto& app = scopi::get_app(); \
-        return app.exit(e);           \
+#include <plog/Log.h>
+
+static plog::Severity log_level = plog::none;
+
+#define SCOPI_PARSE(argc, argv)                                                     \
+    try                                                                             \
+    {                                                                               \
+        auto& app = scopi::get_app();                                               \
+        app.parse(argc, argv);                                                      \
+        plog::init(log_level, fmt::format("{}.log", app.get_description()).data()); \
+    }                                                                               \
+    catch (const CLI::ParseError& e)                                                \
+    {                                                                               \
+        auto& app = scopi::get_app();                                               \
+        return app.exit(e);                                                         \
     }
 
 namespace scopi
@@ -27,7 +32,23 @@ namespace scopi
     inline auto& initialize(const std::string& description = "")
     {
         auto& app = get_app();
-        app.description(description);
+
+        std::map<std::string, plog::Severity> map{
+            {"none",  plog::none },
+            {"info",  plog::info },
+            {"debug", plog::debug}
+        };
+        app.add_option("--log-level", log_level, "Log level")->capture_default_str()->transform(CLI::CheckedTransformer(map, CLI::ignore_case));
+
+        if (description.empty())
+        {
+            app.description("scopi");
+        }
+        else
+        {
+            app.description(description);
+        }
+
         return app;
     }
 }


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what you have done in this PR. -->
This PR gives the possibility to activate or not the logs in scopi using a command line.

For example:

```
./executable --log-level info
```

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/scopi/blob/master/doc/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
