### PR TITLE
fix: contacts when object has several core objects

### DIFF
--- a/include/scopi/contact/contact_kdtree.hpp
+++ b/include/scopi/contact/contact_kdtree.hpp
@@ -221,7 +221,7 @@ namespace scopi
         m_nMatches = 0;
 #pragma omp parallel for reduction(+ : m_nMatches) // num_threads(1)
 
-        for (std::size_t i = particles.offset(active_ptr); i < particles.pos().size() - 1; ++i)
+        for (std::size_t i = active_ptr; i < particles.pos().size() - 1; ++i)
         {
             std::array<double, dim> query_pt;
             for (std::size_t d = 0; d < dim; ++d)
@@ -239,7 +239,7 @@ namespace scopi
 
             for (std::size_t ic = 0; ic < nMatches_loc; ++ic)
             {
-                std::size_t j = ret_matches[ic].first + particles.offset(active_ptr);
+                std::size_t j = ret_matches[ic].first + particles.offset(particles.object_index(active_ptr));
                 if (i < j)
                 {
                     compute_exact_distance<problem_t>(box, particles, contacts, this->get_params().dmax, i, j, m_default_contact_property);

--- a/include/scopi/solver.hpp
+++ b/include/scopi/solver.hpp
@@ -358,7 +358,7 @@ namespace scopi
     auto ScopiSolver<dim, problem_t, optim_solver_t, contact_method_t, vap_t>::compute_contacts() -> contact_container_t
     {
         auto contacts = m_contact_method.run(m_box, m_particles, m_particles.nb_inactive());
-        for (std::size_t i = 0; i < m_particles.size(); ++i)
+        for (std::size_t i = m_particles.object_index(m_particles.nb_inactive()); i < m_particles.size(); ++i)
         {
             add_contact_from_object_dispatcher<dim>::dispatch(*m_particles[i], m_particles.offset(i), contacts);
         }


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what you have done in this PR. -->
This PR fixes two issues:

- When an object is composed by several base objects, such as spheres, the kd tree algorithm is wrong. 
- When an object adds its own contacts, which is the case for the worm, we don't add these contacts if the object is inactive.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/scopi/blob/master/doc/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
