### PR TITLE
refactor: Removed active_ptr

### DIFF
--- a/include/scopi/contact/base.hpp
+++ b/include/scopi/contact/base.hpp
@@ -42,24 +42,22 @@ namespace scopi
          *
          * @tparam dim Dimension (2 or 3).
          * @param particles [in] Array of particles.
-         * @param active_ptr [in] Index of the first active particle.
          *
          * @return Array of neighbors.
          */
         template <std::size_t dim>
-        auto run(const BoxDomain<dim>& box, scopi_container<dim>& particles, std::size_t active_ptr);
+        auto run(const BoxDomain<dim>& box, scopi_container<dim>& particles);
 
         /**
          * @brief Compute contacts between particles.
          *
          * @tparam dim Dimension (2 or 3).
          * @param particles [in] Array of particles.
-         * @param active_ptr [in] Index of the first active particle.
          *
          * @return Array of neighbors.
          */
         template <std::size_t dim>
-        auto run(scopi_container<dim>& particles, std::size_t active_ptr);
+        auto run(scopi_container<dim>& particles);
 
         params_t& get_params();
 
@@ -70,16 +68,19 @@ namespace scopi
 
     template <class D>
     template <std::size_t dim>
-    auto contact_base<D>::run(const BoxDomain<dim>& box, scopi_container<dim>& particles, std::size_t active_ptr)
+    auto contact_base<D>::run(const BoxDomain<dim>& box, scopi_container<dim>& particles)
     {
-        return this->derived_cast().run_impl(box, particles, active_ptr);
+        add_objects_from_periodicity(box, particles, get_params().dmax);
+        auto contacts = this->derived_cast().run_impl(box, particles);
+        particles.reset_periodic();
+        return contacts;
     }
 
     template <class D>
     template <std::size_t dim>
-    auto contact_base<D>::run(scopi_container<dim>& particles, std::size_t active_ptr)
+    auto contact_base<D>::run(scopi_container<dim>& particles)
     {
-        return this->derived_cast().run_impl(BoxDomain<dim>(), particles, active_ptr);
+        return this->derived_cast().run_impl(BoxDomain<dim>(), particles);
     }
 
     template <class D>

--- a/include/scopi/solver.hpp
+++ b/include/scopi/solver.hpp
@@ -357,7 +357,7 @@ namespace scopi
     template <std::size_t dim, class problem_t, class optim_solver_t, template <class> class contact_method_t, class vap_t>
     auto ScopiSolver<dim, problem_t, optim_solver_t, contact_method_t, vap_t>::compute_contacts() -> contact_container_t
     {
-        auto contacts = m_contact_method.run(m_box, m_particles, m_particles.nb_inactive());
+        auto contacts = m_contact_method.run(m_box, m_particles);
         for (std::size_t i = m_particles.object_index(m_particles.nb_inactive()); i < m_particles.size(); ++i)
         {
             add_contact_from_object_dispatcher<dim>::dispatch(*m_particles[i], m_particles.offset(i), contacts);

--- a/test/test_contacts_brute_force.cpp
+++ b/test/test_contacts_brute_force.cpp
@@ -36,7 +36,7 @@ namespace scopi
 
         ContactsParams<contact_brute_force<NoFriction>> params;
         contact_brute_force cont(params);
-        auto contacts = cont.run(particles, 0);
+        auto contacts = cont.run(particles);
 
         SUBCASE("nbContacts")
         {

--- a/test/test_contacts_kdtree.cpp
+++ b/test/test_contacts_kdtree.cpp
@@ -39,7 +39,7 @@ namespace scopi
         ContactsParams<contact_kdtree<NoFriction>> params;
         params.kd_tree_radius = 100.;
         contact_kdtree cont(params);
-        auto contacts = cont.run(particles, 0);
+        auto contacts = cont.run(particles);
 
         SUBCASE("nbContacts")
         {

--- a/test/test_matrices.cpp
+++ b/test/test_matrices.cpp
@@ -35,7 +35,7 @@ namespace scopi
 
         ContactsParams<contact_brute_force<NoFriction>> params;
         contact_brute_force cont(params);
-        auto contacts = cont.run(particles, 0);
+        auto contacts = cont.run(particles);
 
         AMatrix a(contacts, particles);
         ATMatrix at(contacts, particles);
@@ -67,7 +67,7 @@ namespace scopi
 
         ContactsParams<contact_brute_force<NoFriction>> params;
         contact_brute_force<NoFriction> cont(params);
-        auto contacts = cont.run(particles, 0);
+        auto contacts = cont.run(particles);
 
         AMatrix a(contacts, particles);
         xt::xtensor<double, 1> u{0.187562190766376, -1.184390935327111, 0., 0., 0., -0.00453709103433};


### PR DESCRIPTION
## Description
Removed active_ptr parameter from several functions in contact_xxx.hpp to simplify the code and improve clarity.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/scopi/blob/master/doc/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
